### PR TITLE
Fetching of transaction data without a notification

### DIFF
--- a/djpg/__init__.py
+++ b/djpg/__init__.py
@@ -3,6 +3,6 @@ __version__ = '0.1.5'
 __author__ = 'Rafael Canovas'
 __license__ = 'MIT'
 
-from .models import Cart, Item
+from .models import Cart, Item, Transaction
 from .codes import codes
 from . import signals

--- a/djpg/models.py
+++ b/djpg/models.py
@@ -32,6 +32,11 @@ PAYMENT_URL = (
     if PAGSEGURO_SANDBOX else
     'https://pagseguro.uol.com.br/v2/checkout/payment.html'
 )
+TRANSACTIONS_URL = (
+    'https://ws.sandbox.pagseguro.uol.com.br/v2/transactions/'
+    if PAGSEGURO_SANDBOX else
+    'https://ws.pagseguro.uol.com.br/v2/transactions/'
+)
 NOTIFICATIONS_URL = (
     'https://ws.sandbox.pagseguro.uol.com.br/v2/transactions/notifications/'
     if PAGSEGURO_SANDBOX else
@@ -143,6 +148,23 @@ class Cart(object):
     def proceed(self, code):
         endpoint = PAYMENT_URL + '?code=' + code
         return HttpResponseRedirect(endpoint)
+
+
+class Transaction(object):
+    def __init__(self, code):
+        self.code = code
+
+    def fetch_content(self):
+        endpoint = urljoin(TRANSACTIONS_URL, self.code)
+        params = {
+            'email': PAGSEGURO_EMAIL,
+            'token': PAGSEGURO_TOKEN
+        }
+
+        r = requests.get(endpoint, params=params)
+
+        if r.status_code == 200:
+            return xmltodict.parse(r.content, encoding='ISO-8859-1')
 
 
 class Notification(object):

--- a/djpg/signals.py
+++ b/djpg/signals.py
@@ -19,6 +19,7 @@ transaction_unknown = Signal()
 
 def dispatch_transaction(sender, **kwargs):
     transaction = kwargs.pop('transaction')
+    code = int(transaction['code'])
     status = int(transaction['status'])
 
     signals = {
@@ -35,6 +36,7 @@ def dispatch_transaction(sender, **kwargs):
         .get(status, transaction_unknown) \
         .send(sender=None, transaction=transaction)
 
-    logger.info('Transaction with status "%s" dispatched' % (status,))
+    logger.info('Transaction with status "%s" and code "%s" dispatched'
+                % (status, code))
 
 transaction_received.connect(dispatch_transaction)

--- a/djpg/signals.py
+++ b/djpg/signals.py
@@ -19,7 +19,7 @@ transaction_unknown = Signal()
 
 def dispatch_transaction(sender, **kwargs):
     transaction = kwargs.pop('transaction')
-    code = int(transaction['code'])
+    code = transaction['code']
     status = int(transaction['status'])
 
     signals = {

--- a/djpg/urls.py
+++ b/djpg/urls.py
@@ -1,5 +1,6 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
+from .views import notifications
 
-urlpatterns = patterns('djpg.views',
-    url(r'notifications/$', 'notifications', name='pagseguro_notifications'),
-)
+urlpatterns = [
+    url(r'notifications/$', notifications, name='pagseguro_notifications'),
+]

--- a/djpg/views.py
+++ b/djpg/views.py
@@ -14,8 +14,14 @@ from .signals import notification_received, transaction_received
 def notifications(request):
     try:
         notification_type = request.POST['notificationType']
+    except KeyError:
+        logger.info('Notification received without "notificationType"')
+        return HttpResponseBadRequest()
+
+    try:
         notification_code = request.POST['notificationCode']
     except KeyError:
+        logger.info('Notification received without "notificationCode"')
         return HttpResponseBadRequest()
 
     logger.info('Notification with type "%s" and code "%s" received'

--- a/djpg/views.py
+++ b/djpg/views.py
@@ -14,14 +14,8 @@ from .signals import notification_received, transaction_received
 def notifications(request):
     try:
         notification_type = request.POST['notificationType']
-    except KeyError:
-        logger.info('Notification received without "notificationType"')
-        return HttpResponseBadRequest()
-
-    try:
         notification_code = request.POST['notificationCode']
     except KeyError:
-        logger.info('Notification received without "notificationCode"')
         return HttpResponseBadRequest()
 
     logger.info('Notification with type "%s" and code "%s" received'


### PR DESCRIPTION
* Updated `urls.py` for Django >1.6.
* Allow fetching of data from a PagSeguro transaction without a notification, using only the transaction code, via a `Transaction` class. Example:
```python
from django.http import Http404
from django.shortcuts import render
import djpg

def fresh_transaction_data(request, code):
    transaction = djpg.Transaction(code).fetch_content()
    if not transaction:
        raise Http404
    return render(request, "fresh_transaction_data.html", {"transaction": transaction})
```